### PR TITLE
In lollipop and above if plus value is zero it draws entire arc.

### DIFF
--- a/velocimeterlibrary/src/main/java/com/github/glomadrian/velocimeterlibrary/painter/progress/ProgressVelocimeterPainterImp.java
+++ b/velocimeterlibrary/src/main/java/com/github/glomadrian/velocimeterlibrary/painter/progress/ProgressVelocimeterPainterImp.java
@@ -62,6 +62,7 @@ public class ProgressVelocimeterPainterImp implements ProgressVelocimeterPainter
   }
 
   @Override public void draw(Canvas canvas) {
+    if(plusAngle>0)
     canvas.drawArc(circle, startAngle, plusAngle, false, paint);
   }
 


### PR DESCRIPTION
To prevent this , dont draw if plustangle is zero